### PR TITLE
feat(workflow): ブランチ名からIssue番号を抽出するように修正

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -89,19 +89,33 @@ jobs:
       - name: Determine issue number and branch name
         id: get_branch
         run: |
-          TARGET_NUMBER=${{ github.event.issue.number }}
-          
+          ISSUE_NUMBER=""
+          BRANCH_NAME=""
+
+          # If the comment is on a PR
           if [[ -n "${{ github.event.issue.pull_request }}" ]]; then
-            ISSUE_NUMBER=$(gh pr view "$TARGET_NUMBER" --json title -q .title | grep -oE '#[0-9]+' | tr -d '#')
-            if [[ -z "$ISSUE_NUMBER" ]]; then
-              echo "Could not extract issue number from PR title."
+            # Get the branch name from the PR
+            PR_NUMBER=${{ github.event.issue.number }}
+            BRANCH_NAME=$(gh pr view "$PR_NUMBER" --json headRefName -q .headRefName)
+
+            # Extract the issue number from the branch name (e.g., feature/issue-123 -> 123)
+            if [[ "$BRANCH_NAME" =~ ^feature/issue-([0-9]+)$ ]]; then
+              ISSUE_NUMBER="${BASH_REMATCH[1]}"
+            else
+              echo "Could not extract issue number from branch name: $BRANCH_NAME"
               exit 1
             fi
+          # If the comment is directly on an issue
           else
-            ISSUE_NUMBER=$TARGET_NUMBER
+            ISSUE_NUMBER=${{ github.event.issue.number }}
+            BRANCH_NAME="feature/issue-$ISSUE_NUMBER"
           fi
 
-          BRANCH_NAME="feature/issue-$ISSUE_NUMBER"
+          if [[ -z "$ISSUE_NUMBER" || -z "$BRANCH_NAME" ]]; then
+            echo "Failed to determine issue number or branch name."
+            exit 1
+          fi
+
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Issue #23に対応。

PRのタイトルからIssue番号を抽出する代わりに、
PRに紐づくブランチ名から抽出するようにロジックを変更。
これにより、PRのタイトルが変更された場合でも、
安定して正しいIssue番号を特定できるようになった。