### PR TITLE
fix(workflow): ghコマンド実行前にcheckout処理を追加

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -86,6 +86,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Determine issue number and branch name
         id: get_branch
         run: |


### PR DESCRIPTION
gh pr viewコマンドが .git ディレクトリを必要とするため、
`implement`ジョブの先頭で`actions/checkout`を実行するように修正。
これにより、`fatal: not a git repository`エラーを解消。