### PR TITLE
#000 Add time-domain sliding window features for mHealth

### DIFF
--- a/data_flow_dbt/dbt_project.yml
+++ b/data_flow_dbt/dbt_project.yml
@@ -22,6 +22,14 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+vars:
+  # Sliding window configuration for mHealth time-domain feature engineering
+  mhealth_window_size_seconds: 2.56
+  mhealth_window_overlap_percentage: 0.5
+  # The mHealth dataset is sampled at 50 Hz in the original publication.
+  # This value is used to convert the window size (seconds) into row counts.
+  mhealth_sampling_frequency_hz: 50
+
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/data_flow_dbt/models/mhealth/features/fct_mhealth_time_domain_features.sql
+++ b/data_flow_dbt/models/mhealth/features/fct_mhealth_time_domain_features.sql
@@ -1,0 +1,52 @@
+{{ config(materialized='table') }}
+
+{%- set sensor_columns = [
+    'chest_acc_x', 'chest_acc_y', 'chest_acc_z',
+    'chest_ecg_1', 'chest_ecg_2',
+    'left_ankle_acc_x', 'left_ankle_acc_y', 'left_ankle_acc_z',
+    'left_ankle_gyro_x', 'left_ankle_gyro_y', 'left_ankle_gyro_z',
+    'left_ankle_mag_x', 'left_ankle_mag_y', 'left_ankle_mag_z',
+    'right_lower_arm_acc_x', 'right_lower_arm_acc_y', 'right_lower_arm_acc_z',
+    'right_lower_arm_gyro_x', 'right_lower_arm_gyro_y', 'right_lower_arm_gyro_z',
+    'right_lower_arm_mag_x', 'right_lower_arm_mag_y', 'right_lower_arm_mag_z'
+] -%}
+
+WITH windowed AS (
+    SELECT
+        window_id,
+        user_id,
+        activity_label,
+        window_number,
+        window_start,
+        window_end,
+        sample_index,
+        {% for column in sensor_columns %}
+        {{ column }}{% if not loop.last %},{% endif %}
+        {% endfor %}
+    FROM {{ ref('int_mhealth_windowed') }}
+),
+
+aggregated AS (
+    SELECT
+        window_id,
+        user_id,
+        activity_label,
+        MIN(window_number) AS window_number,
+        MIN(window_start) AS window_start,
+        MAX(window_end) AS window_end,
+        COUNT(*) AS sample_count,
+        {% for column in sensor_columns %}
+        AVG(CAST({{ column }} AS double)) AS {{ column }}_mean,
+        STDDEV(CAST({{ column }} AS double)) AS {{ column }}_std,
+        MIN(CAST({{ column }} AS double)) AS {{ column }}_min,
+        MAX(CAST({{ column }} AS double)) AS {{ column }}_max,
+        APPROX_PERCENTILE(CAST({{ column }} AS double), 0.5) AS {{ column }}_median,
+        AVG(ABS(CAST({{ column }} AS double))) AS {{ column }}_mean_abs,
+        SUM(POWER(CAST({{ column }} AS double), 2)) AS {{ column }}_energy,
+        MAX(CAST({{ column }} AS double)) - MIN(CAST({{ column }} AS double)) AS {{ column }}_range{% if not loop.last %},{% endif %}
+        {% endfor %}
+    FROM windowed
+    GROUP BY 1, 2, 3
+)
+
+SELECT * FROM aggregated

--- a/data_flow_dbt/models/mhealth/intermediate/int_mhealth_windowed.sql
+++ b/data_flow_dbt/models/mhealth/intermediate/int_mhealth_windowed.sql
@@ -1,0 +1,168 @@
+{{ config(materialized='table') }}
+
+{%- set window_size_seconds = var('mhealth_window_size_seconds', 2.56) -%}
+{%- set overlap_percentage = var('mhealth_window_overlap_percentage', 0.5) -%}
+{%- set sampling_frequency_hz = var('mhealth_sampling_frequency_hz', 50) -%}
+{%- set window_size_rows = (window_size_seconds * sampling_frequency_hz)|round(0, 'floor')|int -%}
+{%- set window_size_rows = 1 if window_size_rows < 1 else window_size_rows -%}
+{%- set step_size_rows = (window_size_rows * (1 - overlap_percentage))|round(0, 'floor')|int -%}
+{%- set step_size_rows = 1 if step_size_rows < 1 else step_size_rows -%}
+
+WITH base AS (
+    SELECT
+        CAST(subject_id AS varchar) AS user_id,
+        CAST(activity_label AS bigint) AS activity_label,
+        chest_acc_x,
+        chest_acc_y,
+        chest_acc_z,
+        chest_ecg_1,
+        chest_ecg_2,
+        left_ankle_acc_x,
+        left_ankle_acc_y,
+        left_ankle_acc_z,
+        left_ankle_gyro_x,
+        left_ankle_gyro_y,
+        left_ankle_gyro_z,
+        left_ankle_mag_x,
+        left_ankle_mag_y,
+        left_ankle_mag_z,
+        right_lower_arm_acc_x,
+        right_lower_arm_acc_y,
+        right_lower_arm_acc_z,
+        right_lower_arm_gyro_x,
+        right_lower_arm_gyro_y,
+        right_lower_arm_gyro_z,
+        right_lower_arm_mag_x,
+        right_lower_arm_mag_y,
+        right_lower_arm_mag_z,
+        row_number() OVER (
+            PARTITION BY subject_id, activity_label
+            ORDER BY
+                "$path",
+                chest_acc_x,
+                chest_acc_y,
+                chest_acc_z,
+                chest_ecg_1,
+                chest_ecg_2,
+                left_ankle_acc_x,
+                left_ankle_acc_y,
+                left_ankle_acc_z,
+                left_ankle_gyro_x,
+                left_ankle_gyro_y,
+                left_ankle_gyro_z,
+                left_ankle_mag_x,
+                left_ankle_mag_y,
+                left_ankle_mag_z,
+                right_lower_arm_acc_x,
+                right_lower_arm_acc_y,
+                right_lower_arm_acc_z,
+                right_lower_arm_gyro_x,
+                right_lower_arm_gyro_y,
+                right_lower_arm_gyro_z,
+                right_lower_arm_mag_x,
+                right_lower_arm_mag_y,
+                right_lower_arm_mag_z
+        ) - 1 AS sample_index
+    FROM {{ source('mhealth_stage', 'raw_activities') }}
+    WHERE CAST(activity_label AS bigint) != 0
+),
+
+sample_summary AS (
+    SELECT
+        user_id,
+        activity_label,
+        MAX(sample_index) AS max_sample_index
+    FROM base
+    GROUP BY 1, 2
+),
+
+window_starts AS (
+    SELECT
+        user_id,
+        activity_label,
+        window_start,
+        ROW_NUMBER() OVER (
+            PARTITION BY user_id, activity_label
+            ORDER BY window_start
+        ) AS window_number
+    FROM sample_summary
+    CROSS JOIN UNNEST(
+        sequence(
+            0,
+            greatest(max_sample_index - {{ window_size_rows }} + 1, 0),
+            {{ step_size_rows }}
+        )
+    ) AS t(window_start)
+),
+
+windowed AS (
+    SELECT
+        b.user_id,
+        b.activity_label,
+        ws.window_number,
+        ws.window_start,
+        ws.window_start + {{ window_size_rows }} - 1 AS window_end,
+        lpad(CAST(ws.window_number AS varchar), 6, '0') AS window_number_padded,
+        b.sample_index,
+        b.chest_acc_x,
+        b.chest_acc_y,
+        b.chest_acc_z,
+        b.chest_ecg_1,
+        b.chest_ecg_2,
+        b.left_ankle_acc_x,
+        b.left_ankle_acc_y,
+        b.left_ankle_acc_z,
+        b.left_ankle_gyro_x,
+        b.left_ankle_gyro_y,
+        b.left_ankle_gyro_z,
+        b.left_ankle_mag_x,
+        b.left_ankle_mag_y,
+        b.left_ankle_mag_z,
+        b.right_lower_arm_acc_x,
+        b.right_lower_arm_acc_y,
+        b.right_lower_arm_acc_z,
+        b.right_lower_arm_gyro_x,
+        b.right_lower_arm_gyro_y,
+        b.right_lower_arm_gyro_z,
+        b.right_lower_arm_mag_x,
+        b.right_lower_arm_mag_y,
+        b.right_lower_arm_mag_z
+    FROM base b
+    INNER JOIN window_starts ws
+        ON b.user_id = ws.user_id
+        AND b.activity_label = ws.activity_label
+        AND b.sample_index BETWEEN ws.window_start AND ws.window_start + {{ window_size_rows }} - 1
+)
+
+SELECT
+    user_id,
+    activity_label,
+    window_number,
+    CONCAT(user_id, '_', lpad(CAST(activity_label AS varchar), 3, '0'), '_', window_number_padded) AS window_id,
+    window_start,
+    window_end,
+    sample_index,
+    chest_acc_x,
+    chest_acc_y,
+    chest_acc_z,
+    chest_ecg_1,
+    chest_ecg_2,
+    left_ankle_acc_x,
+    left_ankle_acc_y,
+    left_ankle_acc_z,
+    left_ankle_gyro_x,
+    left_ankle_gyro_y,
+    left_ankle_gyro_z,
+    left_ankle_mag_x,
+    left_ankle_mag_y,
+    left_ankle_mag_z,
+    right_lower_arm_acc_x,
+    right_lower_arm_acc_y,
+    right_lower_arm_acc_z,
+    right_lower_arm_gyro_x,
+    right_lower_arm_gyro_y,
+    right_lower_arm_gyro_z,
+    right_lower_arm_mag_x,
+    right_lower_arm_mag_y,
+    right_lower_arm_mag_z
+FROM windowed

--- a/data_flow_dbt/models/schema.yml
+++ b/data_flow_dbt/models/schema.yml
@@ -84,3 +84,53 @@ models:
         description: 右前腕加速度最大（3軸平均の最大値）。
         tests:
           - not_null
+
+  - name: int_mhealth_windowed
+    description: |
+      mHealth の生データをユーザー ID × 活動ラベル単位で 2.56 秒のスライディングウィンドウに区切った中間テーブル。
+      - `dbt_project.yml` の `mhealth_window_size_seconds`・`mhealth_window_overlap_percentage`・`mhealth_sampling_frequency_hz` に従ってウィンドウ幅とステップを計算。
+      - 各レコードは該当するウィンドウ ID (`window_id`) に複製され、時間領域特徴量の計算に利用される。
+    columns:
+      - name: user_id
+        description: Glue の `subject_id` を文字列化したユーザー ID。
+        tests:
+          - not_null
+      - name: activity_label
+        description: 活動ラベル（0 を除外した有効クラス）。
+        tests:
+          - not_null
+      - name: window_id
+        description: ユーザー ID・活動ラベル・ウィンドウ番号を組み合わせた識別子。
+        tests:
+          - not_null
+      - name: window_number
+        description: ユーザー ID × 活動ラベル内でのウィンドウ番号（1 始まり）。
+      - name: window_start
+        description: ウィンドウに含まれるサンプルの開始インデックス。
+      - name: window_end
+        description: ウィンドウに含まれるサンプルの終了インデックス。
+      - name: sample_index
+        description: ユーザー ID × 活動ラベル内でのサンプル順序（0 始まり）。
+
+  - name: fct_mhealth_time_domain_features
+    description: |
+      スライディングウィンドウごとに加速度・ジャイロ・磁気・ECG の各軸の時間領域特徴量（平均・標準偏差・最小・最大・中央値・平均絶対値・エネルギー・レンジ）を算出した特徴量テーブル。
+      - `window_id` ごとにサンプル数 (`sample_count`) やウィンドウ境界も併記する。
+    columns:
+      - name: window_id
+        description: ウィンドウを一意に識別する ID。
+        tests:
+          - not_null
+          - unique
+      - name: user_id
+        description: ウィンドウの元となったユーザー ID。
+        tests:
+          - not_null
+      - name: activity_label
+        description: ウィンドウの活動ラベル。
+        tests:
+          - not_null
+      - name: sample_count
+        description: ウィンドウに含まれるサンプル数（重複を含むレコード数）。
+        tests:
+          - not_null


### PR DESCRIPTION
## Summary
- configure sliding window parameters in `dbt_project.yml` for time-domain feature engineering
- add the `int_mhealth_windowed` intermediate model to expand raw sensor readings into overlapping windows
- create the `fct_mhealth_time_domain_features` model and document the new transformations in `schema.yml`

## Testing
- not run (Athena environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d87b281a2c83298394a360a3ea4163