### PR TITLE
test: implement dbt tests for activities models (#000)

### DIFF
--- a/ai-doc/specs/dbt_test_generation_instructions.md
+++ b/ai-doc/specs/dbt_test_generation_instructions.md
@@ -1,0 +1,222 @@
+# 🧩 AI指示書：7つのベストプラクティスに基づく dbt テスト自動生成仕様書
+
+---
+
+## 🎯 1. ゴール（目的）
+
+この AI は、dbt モデルに対して **「7つのデータ品質ベストプラクティス」** に沿ったテスト定義
+（generic テスト、ユニットテスト、差分テストなど）を自動生成します。
+
+生成されたテストは、レビュー可能かつ CI で即利用可能な形式（SQL / schema.yml）で出力されます。
+
+---
+
+## 🧱 2. 対象範囲・前提条件
+
+- **対象**：dbt モデル（SQL ファイル）＋そのモデルのカラム定義
+- **前提条件**：
+  - モデル SQL が Jinja テンプレート形式（`{{ ref(...) }}` / `{{ source(...) }}`）で記述されている
+  - 主キーまたは一意キーが特定されている
+  - 各列の型情報・NULL可否・カテゴリ値が判明している
+- **入力**：
+  - モデル名・スキーマ名・カラム名・型・制約
+  - 対象モデルの SQL
+  - （任意）旧版のモデルまたは期待出力サンプル
+
+---
+
+## 🧭 3. ベストプラクティス要件（Datafold「7原則」への対応）
+
+| 原則 | AIが実施すべき出力方針 |
+|------|------------------|
+| **1. Shift testing left** | モデル作成・修正時点でテストを同時生成 |
+| **2. Generic tests first** | `not_null`, `unique`, `accepted_values`, `relationships` などの generic テストを優先的に生成 |
+| **3. Unit tests for complex logic** | CASE 式や計算ロジックを含む列に対して、入力／期待出力形式のユニットテストを生成 |
+| **4. Data diff for unknown unknowns** | 旧バージョン／本番データとの差分比較 SQL（diff テスト）を生成 |
+| **5. Test selectively** | 全列を網羅せず、重要列・壊れやすい列・計算列を優先 |
+| **6. Integrate in CI** | 生成されたテストを `dbt test` / `dbt run` に統合できる形式で出力 |
+| **7. Don’t deploy failed PRs** | テストが失敗した場合はマージ禁止を前提にコメントを生成可能 |
+
+---
+
+## 🧩 4. 入力フォーマット仕様（AIが受け取る形式）
+
+```yaml
+model_name: orders_enriched
+schema: marts
+columns:
+  - name: order_id
+    type: integer
+    constraints: [unique, not_null]
+  - name: customer_id
+    type: integer
+    constraints: [not_null]
+  - name: amount
+    type: double
+  - name: status
+    type: varchar
+  - name: ordered_at
+    type: timestamp
+  - name: segment
+    type: varchar
+  - name: is_valid
+    type: boolean
+  - name: amount_rounded
+    type: double
+sql: |
+  with orders as (
+    select * from {{ ref('raw_orders') }}
+  ), customers as (
+    select * from {{ ref('dim_customers') }}
+  )
+  select
+    o.order_id,
+    o.customer_id,
+    cast(o.amount as double) as amount,
+    o.status,
+    cast(o.ordered_at as timestamp) as ordered_at,
+    c.segment,
+    case when o.status = 'paid' and o.amount > 0 then true else false end as is_valid,
+    round(o.amount, 2) as amount_rounded
+  from orders o
+  left join customers c on o.customer_id = c.customer_id
+```
+
+---
+
+## 🧾 5. 出力フォーマット仕様（AIが返す形式）
+
+```yaml
+tests:
+  generic:
+    - test_name: orders_enriched_order_id_not_null
+      type: not_null
+      column: order_id
+    - test_name: orders_enriched_order_id_unique
+      type: unique
+      column: order_id
+    - test_name: orders_enriched_status_accepted_values
+      type: accepted_values
+      column: status
+      values: ['paid','refunded','pending','canceled']
+
+  unit:
+    - test_name: ut_orders_enriched_basic_logic
+      sql: |
+        with input_orders as (
+          select 1 as order_id, 100 as customer_id, 1200.0 as amount, 'paid' as status, '2024-04-01 10:00:00' as ordered_at
+          union all
+          select 2, 101, 0.0, 'refunded', '2024-04-01 11:00:00'
+        ), input_customers as (
+          select 100 as customer_id, 'prime' as segment
+          union all
+          select 101, 'regular'
+        ), expected as (
+          select 1 as order_id, 100 as customer_id, 1200.0 as amount, 'paid' as status, cast('2024-04-01 10:00:00' as timestamp) as ordered_at, 'prime' as segment, true as is_valid, 1200.00 as amount_rounded
+          union all
+          select 2, 101, 0.0, 'refunded', cast('2024-04-01 11:00:00' as timestamp), 'regular', false, 0.00
+        )
+        select * from expected
+        except
+        select
+          o.order_id,
+          o.customer_id,
+          cast(o.amount as double) as amount,
+          o.status,
+          cast(o.ordered_at as timestamp) as ordered_at,
+          c.segment,
+          case when o.status = 'paid' and o.amount > 0 then true else false end as is_valid,
+          round(o.amount, 2) as amount_rounded
+        from input_orders o
+        left join input_customers c on o.customer_id = c.customer_id
+
+  diff:
+    - test_name: diff_orders_enriched_vs_baseline
+      sql: |
+        with old as (select * from baseline_db.orders_enriched),
+             new as (select * from {{ this }})
+        select 'missing_in_new' as diff_type, * from old
+        except
+        select 'missing_in_new', * from new
+        union all
+        select 'unexpected_in_new' as diff_type, * from new
+        except
+        select 'unexpected_in_new', * from old
+```
+
+---
+
+## ⚙️ 6. テスト生成ルール・優先順位
+
+1. **generic テストを最初に生成**
+   （基本的なデータ品質をカバー）
+2. **CASE・ROUND・JOIN などの計算ロジックを含む列に対しユニットテストを生成**
+3. **モデル全体に対して差分テストを生成**
+4. **Athena/Trino 方言対応** — `EXCEPT` が使えない場合はアンチジョイン方式を利用
+5. **比較前に正規化**：`round()`・`cast(... as varchar)`・日付フォーマットを統一
+6. **重要列優先**：全列網羅せず、主要・脆弱な列に注力
+7. **返却行数0 = テスト成功**（dbt標準に準拠）
+8. **仕様変更がある場合は許容コメントを生成**
+
+---
+
+## 🔧 7. 制約・ノウハウ
+
+- Athena / Trino の SQL 方言を考慮
+- 浮動小数点誤差・丸め誤差対策を組み込む
+- 日時型は UTC とローカルの差異を回避するためフォーマット統一
+- 列順差・NULL許容差は比較ロジック内で吸収
+- 大規模テーブルではハッシュ比較テスト（`md5(concat_ws(...))`）を採用可能
+- 生成SQL / YAMLは「即利用可能な構文整形済み」
+- 期待値は最小＋境界ケースを含める
+- 出力後に人間レビュー必須（意図誤読リスク回避）
+
+---
+
+## 🧠 8. プロンプト文テンプレート（AIに渡す命令）
+
+```
+あなたは **dbt データ品質エンジニア** です。
+以下の条件に従って、**dbt モデルに対するテスト定義（generic / unit / diff）** を自動生成してください。
+
+### 入力（YAML + SQL）
+```
+{入力 YAML + SQL}
+```
+
+### 要件（7つのベストプラクティスに基づく）
+1. 基本 generic テスト（not_null, unique, accepted_values, relationships）を生成
+2. CASE式や計算列には最小入力＋期待出力形式のユニットテストを生成
+3. モデル全体に対し baseline との diff 比較テストを生成
+4. Athena / Trino 対応。`EXCEPT` 不可の場合はアンチジョインを使用
+5. 数値・日時・文字列を比較前に正規化
+6. 全列ではなく、重要・壊れやすい列にテストを限定
+7. 出力形式は以下仕様に従う
+
+### 出力形式
+```
+tests:
+  generic:
+    - test_name: ...
+      type: ...
+      column: ...
+      [values: [...]]
+  unit:
+    - test_name: ...
+      sql: |
+        ...
+  diff:
+    - test_name: ...
+      sql: |
+        ...
+```
+
+- `generic`: schema.yml にそのまま貼り付け可能な形式
+- `unit`: モデルロジック単位の入力＋期待出力 SQL
+- `diff`: baseline 比較 SQL
+- 各 `test_name` は一意で明確に命名
+- SQL 内では `{{ ref(...) }}`, `{{ this }}` を活用
+
+以上を踏まえ、ベストプラクティスに沿ったテストを出力してください。
+必要であれば例外許容コメントも付与してください。
+```

--- a/data_flow_dbt/macros/tests/unique_combination_of_columns.sql
+++ b/data_flow_dbt/macros/tests/unique_combination_of_columns.sql
@@ -1,0 +1,18 @@
+{% macro _build_group_by_list(columns) %}
+  {%- for column in columns -%}
+    {{ column }}{% if not loop.last %}, {% endif %}
+  {%- endfor -%}
+{% endmacro %}
+
+{% test unique_combination_of_columns(model, combination) %}
+with duplicates as (
+    select
+        {{ _build_group_by_list(combination) }},
+        count(*) as duplicate_count
+    from {{ model }}
+    group by {{ _build_group_by_list(combination) }}
+    having count(*) > 1
+)
+
+select * from duplicates
+{% endtest %}

--- a/data_flow_dbt/models/schema.yml
+++ b/data_flow_dbt/models/schema.yml
@@ -27,15 +27,26 @@ models:
     description: |
       cleaned_activities を `user_id × activity_label` で集約し、3軸平均の代表統計量を算出した特徴量テーブル。
       - chest / left_ankle / right_lower_arm それぞれについて mean / std / min / max を計算。
+    tests:
+      - unique_combination_of_columns:
+          combination:
+            - user_id
+            - activity_label
     columns:
       - name: user_id
         description: ユーザー ID。
         tests:
           - not_null
+          - relationships:
+              to: ref('cleaned_activities')
+              field: user_id
       - name: activity_label
         description: 活動ラベル（1 以降の有効クラス）。
         tests:
           - not_null
+          - relationships:
+              to: ref('cleaned_activities')
+              field: activity_label
       - name: chest_acc_mean
         description: 胸部加速度平均（3軸平均の平均値）。
         tests:

--- a/data_flow_dbt/tests/cleaned_activities_activity_label_positive.sql
+++ b/data_flow_dbt/tests/cleaned_activities_activity_label_positive.sql
@@ -1,0 +1,10 @@
+with invalid_labels as (
+    select
+        user_id,
+        activity_label
+    from {{ ref('cleaned_activities') }}
+    where activity_label <= 0
+)
+
+select *
+from invalid_labels

--- a/data_flow_dbt/tests/diff_featured_activities_vs_cleaned.sql
+++ b/data_flow_dbt/tests/diff_featured_activities_vs_cleaned.sql
@@ -1,0 +1,133 @@
+with aggregated as (
+    select
+        user_id,
+        activity_label,
+        round(avg(chest_acc_avg), 6) as chest_acc_mean,
+        round(stddev(chest_acc_avg), 6) as chest_acc_std,
+        round(min(chest_acc_avg), 6) as chest_acc_min,
+        round(max(chest_acc_avg), 6) as chest_acc_max,
+        round(avg(left_ankle_acc_avg), 6) as left_ankle_acc_mean,
+        round(stddev(left_ankle_acc_avg), 6) as left_ankle_acc_std,
+        round(min(left_ankle_acc_avg), 6) as left_ankle_acc_min,
+        round(max(left_ankle_acc_avg), 6) as left_ankle_acc_max,
+        round(avg(right_lower_arm_acc_avg), 6) as right_lower_arm_acc_mean,
+        round(stddev(right_lower_arm_acc_avg), 6) as right_lower_arm_acc_std,
+        round(min(right_lower_arm_acc_avg), 6) as right_lower_arm_acc_min,
+        round(max(right_lower_arm_acc_avg), 6) as right_lower_arm_acc_max
+    from {{ ref('cleaned_activities') }}
+    group by user_id, activity_label
+),
+
+featured as (
+    select
+        user_id,
+        activity_label,
+        round(chest_acc_mean, 6) as chest_acc_mean,
+        round(chest_acc_std, 6) as chest_acc_std,
+        round(chest_acc_min, 6) as chest_acc_min,
+        round(chest_acc_max, 6) as chest_acc_max,
+        round(left_ankle_acc_mean, 6) as left_ankle_acc_mean,
+        round(left_ankle_acc_std, 6) as left_ankle_acc_std,
+        round(left_ankle_acc_min, 6) as left_ankle_acc_min,
+        round(left_ankle_acc_max, 6) as left_ankle_acc_max,
+        round(right_lower_arm_acc_mean, 6) as right_lower_arm_acc_mean,
+        round(right_lower_arm_acc_std, 6) as right_lower_arm_acc_std,
+        round(right_lower_arm_acc_min, 6) as right_lower_arm_acc_min,
+        round(right_lower_arm_acc_max, 6) as right_lower_arm_acc_max
+    from {{ ref('featured_activities') }}
+),
+
+missing_in_featured as (
+    select
+        'missing_in_featured' as diff_type,
+        agg.user_id,
+        agg.activity_label,
+        agg.chest_acc_mean,
+        agg.chest_acc_std,
+        agg.chest_acc_min,
+        agg.chest_acc_max,
+        agg.left_ankle_acc_mean,
+        agg.left_ankle_acc_std,
+        agg.left_ankle_acc_min,
+        agg.left_ankle_acc_max,
+        agg.right_lower_arm_acc_mean,
+        agg.right_lower_arm_acc_std,
+        agg.right_lower_arm_acc_min,
+        agg.right_lower_arm_acc_max,
+        'expected aggregate row missing from featured_activities' as details
+    from aggregated agg
+    left join featured feat
+        on agg.user_id = feat.user_id
+       and agg.activity_label = feat.activity_label
+    where feat.user_id is null
+),
+
+unexpected_in_featured as (
+    select
+        'unexpected_in_featured' as diff_type,
+        feat.user_id,
+        feat.activity_label,
+        feat.chest_acc_mean,
+        feat.chest_acc_std,
+        feat.chest_acc_min,
+        feat.chest_acc_max,
+        feat.left_ankle_acc_mean,
+        feat.left_ankle_acc_std,
+        feat.left_ankle_acc_min,
+        feat.left_ankle_acc_max,
+        feat.right_lower_arm_acc_mean,
+        feat.right_lower_arm_acc_std,
+        feat.right_lower_arm_acc_min,
+        feat.right_lower_arm_acc_max,
+        'unexpected aggregate row produced by featured_activities' as details
+    from featured feat
+    left join aggregated agg
+        on agg.user_id = feat.user_id
+       and agg.activity_label = feat.activity_label
+    where agg.user_id is null
+),
+
+metric_mismatches as (
+    select
+        'metric_mismatch' as diff_type,
+        agg.user_id,
+        agg.activity_label,
+        agg.chest_acc_mean,
+        agg.chest_acc_std,
+        agg.chest_acc_min,
+        agg.chest_acc_max,
+        agg.left_ankle_acc_mean,
+        agg.left_ankle_acc_std,
+        agg.left_ankle_acc_min,
+        agg.left_ankle_acc_max,
+        agg.right_lower_arm_acc_mean,
+        agg.right_lower_arm_acc_std,
+        agg.right_lower_arm_acc_min,
+        agg.right_lower_arm_acc_max,
+        'feature row present but metric values differ from recomputed aggregate' as details
+    from aggregated agg
+    join featured feat
+        on agg.user_id = feat.user_id
+       and agg.activity_label = feat.activity_label
+    where abs(coalesce(agg.chest_acc_mean, 0) - coalesce(feat.chest_acc_mean, 0)) > 1e-6
+       or (agg.chest_acc_std is null) <> (feat.chest_acc_std is null)
+       or (agg.chest_acc_std is not null and feat.chest_acc_std is not null and abs(agg.chest_acc_std - feat.chest_acc_std) > 1e-6)
+       or abs(coalesce(agg.chest_acc_min, 0) - coalesce(feat.chest_acc_min, 0)) > 1e-6
+       or abs(coalesce(agg.chest_acc_max, 0) - coalesce(feat.chest_acc_max, 0)) > 1e-6
+       or abs(coalesce(agg.left_ankle_acc_mean, 0) - coalesce(feat.left_ankle_acc_mean, 0)) > 1e-6
+       or (agg.left_ankle_acc_std is null) <> (feat.left_ankle_acc_std is null)
+       or (agg.left_ankle_acc_std is not null and feat.left_ankle_acc_std is not null and abs(agg.left_ankle_acc_std - feat.left_ankle_acc_std) > 1e-6)
+       or abs(coalesce(agg.left_ankle_acc_min, 0) - coalesce(feat.left_ankle_acc_min, 0)) > 1e-6
+       or abs(coalesce(agg.left_ankle_acc_max, 0) - coalesce(feat.left_ankle_acc_max, 0)) > 1e-6
+       or abs(coalesce(agg.right_lower_arm_acc_mean, 0) - coalesce(feat.right_lower_arm_acc_mean, 0)) > 1e-6
+       or (agg.right_lower_arm_acc_std is null) <> (feat.right_lower_arm_acc_std is null)
+       or (agg.right_lower_arm_acc_std is not null and feat.right_lower_arm_acc_std is not null and abs(agg.right_lower_arm_acc_std - feat.right_lower_arm_acc_std) > 1e-6)
+       or abs(coalesce(agg.right_lower_arm_acc_min, 0) - coalesce(feat.right_lower_arm_acc_min, 0)) > 1e-6
+       or abs(coalesce(agg.right_lower_arm_acc_max, 0) - coalesce(feat.right_lower_arm_acc_max, 0)) > 1e-6
+)
+
+select * from missing_in_featured
+union all
+select * from unexpected_in_featured
+union all
+select * from metric_mismatches

--- a/data_flow_dbt/tests/unit_cleaned_activities_basic_logic.sql
+++ b/data_flow_dbt/tests/unit_cleaned_activities_basic_logic.sql
@@ -1,0 +1,111 @@
+with input_raw as (
+    select
+        1 as subject_id,
+        1 as activity_label,
+        0.9 as chest_acc_x,
+        0.3 as chest_acc_y,
+        0.6 as chest_acc_z,
+        0.4 as left_ankle_acc_x,
+        0.5 as left_ankle_acc_y,
+        0.1 as left_ankle_acc_z,
+        0.2 as right_lower_arm_acc_x,
+        0.4 as right_lower_arm_acc_y,
+        0.6 as right_lower_arm_acc_z,
+        's3://bucket/stage/subject_id=1/activity_label=1/file.parquet' as "$path"
+    union all
+    select
+        1,
+        0,
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.7,
+        0.8,
+        0.9,
+        's3://bucket/stage/subject_id=1/activity_label=0/file.parquet' as "$path"
+),
+
+expected as (
+    select
+        cast('1' as varchar) as user_id,
+        cast(1 as bigint) as activity_label,
+        cast(0.6 as double) as chest_acc_avg,
+        cast(0.3333333333 as double) as left_ankle_acc_avg,
+        cast(0.4 as double) as right_lower_arm_acc_avg
+),
+
+actual as (
+    select
+        cast(subject_id as varchar) as user_id,
+        cast(activity_label as bigint) as activity_label,
+        (chest_acc_x + chest_acc_y + chest_acc_z) / 3 as chest_acc_avg,
+        (left_ankle_acc_x + left_ankle_acc_y + left_ankle_acc_z) / 3 as left_ankle_acc_avg,
+        (right_lower_arm_acc_x + right_lower_arm_acc_y + right_lower_arm_acc_z) / 3 as right_lower_arm_acc_avg
+    from input_raw
+    where cast(activity_label as bigint) != 0
+),
+
+missing_in_actual as (
+    select
+        'missing_in_actual' as diff_type,
+        e.user_id,
+        e.activity_label,
+        e.chest_acc_avg as expected_chest_acc_avg,
+        cast(null as double) as actual_chest_acc_avg,
+        e.left_ankle_acc_avg as expected_left_ankle_acc_avg,
+        cast(null as double) as actual_left_ankle_acc_avg,
+        e.right_lower_arm_acc_avg as expected_right_lower_arm_acc_avg,
+        cast(null as double) as actual_right_lower_arm_acc_avg
+    from expected e
+    left join actual a
+        on e.user_id = a.user_id
+       and e.activity_label = a.activity_label
+    where a.user_id is null
+),
+
+unexpected_in_actual as (
+    select
+        'unexpected_in_actual' as diff_type,
+        a.user_id,
+        a.activity_label,
+        cast(null as double) as expected_chest_acc_avg,
+        a.chest_acc_avg as actual_chest_acc_avg,
+        cast(null as double) as expected_left_ankle_acc_avg,
+        a.left_ankle_acc_avg as actual_left_ankle_acc_avg,
+        cast(null as double) as expected_right_lower_arm_acc_avg,
+        a.right_lower_arm_acc_avg as actual_right_lower_arm_acc_avg
+    from actual a
+    left join expected e
+        on e.user_id = a.user_id
+       and e.activity_label = a.activity_label
+    where e.user_id is null
+),
+
+mismatched_values as (
+    select
+        'mismatched_values' as diff_type,
+        e.user_id,
+        e.activity_label,
+        e.chest_acc_avg as expected_chest_acc_avg,
+        a.chest_acc_avg as actual_chest_acc_avg,
+        e.left_ankle_acc_avg as expected_left_ankle_acc_avg,
+        a.left_ankle_acc_avg as actual_left_ankle_acc_avg,
+        e.right_lower_arm_acc_avg as expected_right_lower_arm_acc_avg,
+        a.right_lower_arm_acc_avg as actual_right_lower_arm_acc_avg
+    from expected e
+    join actual a
+        on e.user_id = a.user_id
+       and e.activity_label = a.activity_label
+    where abs(e.chest_acc_avg - a.chest_acc_avg) > 1e-6
+       or abs(e.left_ankle_acc_avg - a.left_ankle_acc_avg) > 1e-6
+       or abs(e.right_lower_arm_acc_avg - a.right_lower_arm_acc_avg) > 1e-6
+)
+
+select * from missing_in_actual
+union all
+select * from unexpected_in_actual
+union all
+select * from mismatched_values

--- a/data_flow_dbt/tests/unit_featured_activities_aggregations.sql
+++ b/data_flow_dbt/tests/unit_featured_activities_aggregations.sql
@@ -1,0 +1,218 @@
+with cleaned_input as (
+    select '1' as user_id, cast(1 as bigint) as activity_label, 0.2 as chest_acc_avg, 0.4 as left_ankle_acc_avg, 0.6 as right_lower_arm_acc_avg
+    union all
+    select '1', cast(1 as bigint), 0.4, 0.2, 0.8
+    union all
+    select '1', cast(2 as bigint), 0.1, 0.3, 0.5
+    union all
+    select '2', cast(1 as bigint), 0.5, 0.7, 0.9
+),
+
+expected as (
+    select * from (values
+        ('1', cast(1 as bigint), 0.3, 0.1414213562, 0.2, 0.4, 0.3, 0.1414213562, 0.2, 0.4, 0.7, 0.1414213562, 0.6, 0.8),
+        ('1', cast(2 as bigint), 0.1, cast(null as double), 0.1, 0.1, 0.3, cast(null as double), 0.3, 0.3, 0.5, cast(null as double), 0.5, 0.5),
+        ('2', cast(1 as bigint), 0.5, cast(null as double), 0.5, 0.5, 0.7, cast(null as double), 0.7, 0.7, 0.9, cast(null as double), 0.9, 0.9)
+    ) as t(
+        user_id,
+        activity_label,
+        chest_acc_mean,
+        chest_acc_std,
+        chest_acc_min,
+        chest_acc_max,
+        left_ankle_acc_mean,
+        left_ankle_acc_std,
+        left_ankle_acc_min,
+        left_ankle_acc_max,
+        right_lower_arm_acc_mean,
+        right_lower_arm_acc_std,
+        right_lower_arm_acc_min,
+        right_lower_arm_acc_max
+    )
+),
+
+rounded_expected as (
+    select
+        user_id,
+        activity_label,
+        round(chest_acc_mean, 6) as chest_acc_mean,
+        round(chest_acc_std, 6) as chest_acc_std,
+        round(chest_acc_min, 6) as chest_acc_min,
+        round(chest_acc_max, 6) as chest_acc_max,
+        round(left_ankle_acc_mean, 6) as left_ankle_acc_mean,
+        round(left_ankle_acc_std, 6) as left_ankle_acc_std,
+        round(left_ankle_acc_min, 6) as left_ankle_acc_min,
+        round(left_ankle_acc_max, 6) as left_ankle_acc_max,
+        round(right_lower_arm_acc_mean, 6) as right_lower_arm_acc_mean,
+        round(right_lower_arm_acc_std, 6) as right_lower_arm_acc_std,
+        round(right_lower_arm_acc_min, 6) as right_lower_arm_acc_min,
+        round(right_lower_arm_acc_max, 6) as right_lower_arm_acc_max
+    from expected
+),
+
+actual as (
+    select
+        user_id,
+        activity_label,
+        avg(chest_acc_avg) as chest_acc_mean,
+        stddev(chest_acc_avg) as chest_acc_std,
+        min(chest_acc_avg) as chest_acc_min,
+        max(chest_acc_avg) as chest_acc_max,
+        avg(left_ankle_acc_avg) as left_ankle_acc_mean,
+        stddev(left_ankle_acc_avg) as left_ankle_acc_std,
+        min(left_ankle_acc_avg) as left_ankle_acc_min,
+        max(left_ankle_acc_avg) as left_ankle_acc_max,
+        avg(right_lower_arm_acc_avg) as right_lower_arm_acc_mean,
+        stddev(right_lower_arm_acc_avg) as right_lower_arm_acc_std,
+        min(right_lower_arm_acc_avg) as right_lower_arm_acc_min,
+        max(right_lower_arm_acc_avg) as right_lower_arm_acc_max
+    from cleaned_input
+    group by user_id, activity_label
+),
+
+rounded_actual as (
+    select
+        user_id,
+        activity_label,
+        round(chest_acc_mean, 6) as chest_acc_mean,
+        round(chest_acc_std, 6) as chest_acc_std,
+        round(chest_acc_min, 6) as chest_acc_min,
+        round(chest_acc_max, 6) as chest_acc_max,
+        round(left_ankle_acc_mean, 6) as left_ankle_acc_mean,
+        round(left_ankle_acc_std, 6) as left_ankle_acc_std,
+        round(left_ankle_acc_min, 6) as left_ankle_acc_min,
+        round(left_ankle_acc_max, 6) as left_ankle_acc_max,
+        round(right_lower_arm_acc_mean, 6) as right_lower_arm_acc_mean,
+        round(right_lower_arm_acc_std, 6) as right_lower_arm_acc_std,
+        round(right_lower_arm_acc_min, 6) as right_lower_arm_acc_min,
+        round(right_lower_arm_acc_max, 6) as right_lower_arm_acc_max
+    from actual
+),
+
+missing_in_actual as (
+    select
+        'missing_in_actual' as diff_type,
+        e.user_id,
+        e.activity_label,
+        e.chest_acc_mean as expected_chest_acc_mean,
+        cast(null as double) as actual_chest_acc_mean,
+        e.chest_acc_std as expected_chest_acc_std,
+        cast(null as double) as actual_chest_acc_std,
+        e.chest_acc_min as expected_chest_acc_min,
+        cast(null as double) as actual_chest_acc_min,
+        e.chest_acc_max as expected_chest_acc_max,
+        cast(null as double) as actual_chest_acc_max,
+        e.left_ankle_acc_mean as expected_left_ankle_acc_mean,
+        cast(null as double) as actual_left_ankle_acc_mean,
+        e.left_ankle_acc_std as expected_left_ankle_acc_std,
+        cast(null as double) as actual_left_ankle_acc_std,
+        e.left_ankle_acc_min as expected_left_ankle_acc_min,
+        cast(null as double) as actual_left_ankle_acc_min,
+        e.left_ankle_acc_max as expected_left_ankle_acc_max,
+        cast(null as double) as actual_left_ankle_acc_max,
+        e.right_lower_arm_acc_mean as expected_right_lower_arm_acc_mean,
+        cast(null as double) as actual_right_lower_arm_acc_mean,
+        e.right_lower_arm_acc_std as expected_right_lower_arm_acc_std,
+        cast(null as double) as actual_right_lower_arm_acc_std,
+        e.right_lower_arm_acc_min as expected_right_lower_arm_acc_min,
+        cast(null as double) as actual_right_lower_arm_acc_min,
+        e.right_lower_arm_acc_max as expected_right_lower_arm_acc_max,
+        cast(null as double) as actual_right_lower_arm_acc_max
+    from rounded_expected e
+    left join rounded_actual a
+        on e.user_id = a.user_id
+       and e.activity_label = a.activity_label
+    where a.user_id is null
+),
+
+unexpected_in_actual as (
+    select
+        'unexpected_in_actual' as diff_type,
+        a.user_id,
+        a.activity_label,
+        cast(null as double) as expected_chest_acc_mean,
+        a.chest_acc_mean as actual_chest_acc_mean,
+        cast(null as double) as expected_chest_acc_std,
+        a.chest_acc_std as actual_chest_acc_std,
+        cast(null as double) as expected_chest_acc_min,
+        a.chest_acc_min as actual_chest_acc_min,
+        cast(null as double) as expected_chest_acc_max,
+        a.chest_acc_max as actual_chest_acc_max,
+        cast(null as double) as expected_left_ankle_acc_mean,
+        a.left_ankle_acc_mean as actual_left_ankle_acc_mean,
+        cast(null as double) as expected_left_ankle_acc_std,
+        a.left_ankle_acc_std as actual_left_ankle_acc_std,
+        cast(null as double) as expected_left_ankle_acc_min,
+        a.left_ankle_acc_min as actual_left_ankle_acc_min,
+        cast(null as double) as expected_left_ankle_acc_max,
+        a.left_ankle_acc_max as actual_left_ankle_acc_max,
+        cast(null as double) as expected_right_lower_arm_acc_mean,
+        a.right_lower_arm_acc_mean as actual_right_lower_arm_acc_mean,
+        cast(null as double) as expected_right_lower_arm_acc_std,
+        a.right_lower_arm_acc_std as actual_right_lower_arm_acc_std,
+        cast(null as double) as expected_right_lower_arm_acc_min,
+        a.right_lower_arm_acc_min as actual_right_lower_arm_acc_min,
+        cast(null as double) as expected_right_lower_arm_acc_max,
+        a.right_lower_arm_acc_max as actual_right_lower_arm_acc_max
+    from rounded_actual a
+    left join rounded_expected e
+        on e.user_id = a.user_id
+       and e.activity_label = a.activity_label
+    where e.user_id is null
+),
+
+mismatched_values as (
+    select
+        'mismatched_values' as diff_type,
+        e.user_id,
+        e.activity_label,
+        e.chest_acc_mean as expected_chest_acc_mean,
+        a.chest_acc_mean as actual_chest_acc_mean,
+        e.chest_acc_std as expected_chest_acc_std,
+        a.chest_acc_std as actual_chest_acc_std,
+        e.chest_acc_min as expected_chest_acc_min,
+        a.chest_acc_min as actual_chest_acc_min,
+        e.chest_acc_max as expected_chest_acc_max,
+        a.chest_acc_max as actual_chest_acc_max,
+        e.left_ankle_acc_mean as expected_left_ankle_acc_mean,
+        a.left_ankle_acc_mean as actual_left_ankle_acc_mean,
+        e.left_ankle_acc_std as expected_left_ankle_acc_std,
+        a.left_ankle_acc_std as actual_left_ankle_acc_std,
+        e.left_ankle_acc_min as expected_left_ankle_acc_min,
+        a.left_ankle_acc_min as actual_left_ankle_acc_min,
+        e.left_ankle_acc_max as expected_left_ankle_acc_max,
+        a.left_ankle_acc_max as actual_left_ankle_acc_max,
+        e.right_lower_arm_acc_mean as expected_right_lower_arm_acc_mean,
+        a.right_lower_arm_acc_mean as actual_right_lower_arm_acc_mean,
+        e.right_lower_arm_acc_std as expected_right_lower_arm_acc_std,
+        a.right_lower_arm_acc_std as actual_right_lower_arm_acc_std,
+        e.right_lower_arm_acc_min as expected_right_lower_arm_acc_min,
+        a.right_lower_arm_acc_min as actual_right_lower_arm_acc_min,
+        e.right_lower_arm_acc_max as expected_right_lower_arm_acc_max,
+        a.right_lower_arm_acc_max as actual_right_lower_arm_acc_max
+    from rounded_expected e
+    join rounded_actual a
+        on e.user_id = a.user_id
+       and e.activity_label = a.activity_label
+    where abs(coalesce(e.chest_acc_mean, 0) - coalesce(a.chest_acc_mean, 0)) > 1e-6
+       or (e.chest_acc_std is null) <> (a.chest_acc_std is null)
+       or (e.chest_acc_std is not null and a.chest_acc_std is not null and abs(e.chest_acc_std - a.chest_acc_std) > 1e-6)
+       or abs(coalesce(e.chest_acc_min, 0) - coalesce(a.chest_acc_min, 0)) > 1e-6
+       or abs(coalesce(e.chest_acc_max, 0) - coalesce(a.chest_acc_max, 0)) > 1e-6
+       or abs(coalesce(e.left_ankle_acc_mean, 0) - coalesce(a.left_ankle_acc_mean, 0)) > 1e-6
+       or (e.left_ankle_acc_std is null) <> (a.left_ankle_acc_std is null)
+       or (e.left_ankle_acc_std is not null and a.left_ankle_acc_std is not null and abs(e.left_ankle_acc_std - a.left_ankle_acc_std) > 1e-6)
+       or abs(coalesce(e.left_ankle_acc_min, 0) - coalesce(a.left_ankle_acc_min, 0)) > 1e-6
+       or abs(coalesce(e.left_ankle_acc_max, 0) - coalesce(a.left_ankle_acc_max, 0)) > 1e-6
+       or abs(coalesce(e.right_lower_arm_acc_mean, 0) - coalesce(a.right_lower_arm_acc_mean, 0)) > 1e-6
+       or (e.right_lower_arm_acc_std is null) <> (a.right_lower_arm_acc_std is null)
+       or (e.right_lower_arm_acc_std is not null and a.right_lower_arm_acc_std is not null and abs(e.right_lower_arm_acc_std - a.right_lower_arm_acc_std) > 1e-6)
+       or abs(coalesce(e.right_lower_arm_acc_min, 0) - coalesce(a.right_lower_arm_acc_min, 0)) > 1e-6
+       or abs(coalesce(e.right_lower_arm_acc_max, 0) - coalesce(a.right_lower_arm_acc_max, 0)) > 1e-6
+)
+
+select * from missing_in_actual
+union all
+select * from unexpected_in_actual
+union all
+select * from mismatched_values


### PR DESCRIPTION
## Summary
- enforce user/activity uniqueness and referential integrity for `featured_activities`
- add singular tests to keep `cleaned_activities` activity labels positive
- provide unit and diff SQL tests to validate aggregation logic for both models

## Testing
- not run (dbt requires an external warehouse connection)


------
https://chatgpt.com/codex/tasks/task_e_68e21c43d9188329a5318704a574fd57