### PR TITLE
feat: implement comprehensive dbt capabilities

### DIFF
--- a/data_flow_dbt/README.md
+++ b/data_flow_dbt/README.md
@@ -1,15 +1,44 @@
-Welcome to your new dbt project!
+# data_flow_dbt プロジェクト
 
-### Using the starter project
+mHealth ログデータを Athena 上で分析するための dbt プロジェクトです。ソース宣言、ステージング、特徴量生成、スナップショット、メトリクスおよびエクスポージャー定義、CI スクリプトを含み、dbt の主要機能をカバーしています。
 
-Try running the following commands:
-- dbt run
-- dbt test
+## 主なディレクトリ
+- `models/staging/`: 外部テーブルを正規化するビュー（データコントラクト対応）。
+- `models/intermediate/`: エフェメラル中間モデル。
+- `models/`: テーブル・インクリメンタルマートとドキュメント。
+- `seeds/`: `activity_labels` シード（参照ディメンション）。
+- `snapshots/`: `featured_activities` の SCD2 管理。
+- `macros/`: 3 軸平均マクロ、カスタムテスト、アーティファクト集計、run-operation 用マクロ。
+- `exposures/`: ダッシュボードや ML パイプラインとの依存関係。
+- `scripts/ci/`: Slim CI を想定したビルド・アーティファクトアップロードスクリプト。
 
+## 推奨コマンド
+```bash
+dbt deps
+dbt seed
+# state:modified セレクタを活用した差分ビルド
+mkdir -p state && cp -r target state  # 初回は空でも可
+dbt build --selector state_modified_plus_seeds --state state
 
-### Resources:
-- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
-- Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
-- Find [dbt events](https://events.getdbt.com) near you
-- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices
+dbt snapshot
+
+dbt run-operation log_lineage --args '{"model_name": "fact_activity_metrics"}'
+
+dbt docs generate && dbt docs serve
+```
+
+## CI 運用
+- `scripts/ci/dbt_slim_ci.sh` を利用し、Slim CI + アーティファクト（manifest.json/run_results.json/catalog.json）を S3 へアップロードします。
+- `selectors.yml` で state:modified とシードを組み合わせたセレクタを提供。
+- `profiles.yml` で dev/stg/prod 環境を切り替え可能。
+
+## 品質保証
+- シード・モデルに対して `not_null`、`unique`、`relationships`、`non_negative` などのテストを定義。
+- `fact_activity_metrics` にはカスタムデータテスト（負値検出）を追加。
+- `stg_mhealth_activities` は契約 (`contract.enforced`) を有効化。
+- `sources` で freshness 監視を設定。
+
+## 拡張
+- `packages.yml` で `dbt_utils` と `elementary` を導入。`elementary` による品質レポート出力や Great Expectations 連携の基礎として利用可能。
+- `metrics.yml` に Semantic Layer 用メトリクスを定義。
+- `exposures` を利用し、BI/ML 下流資産とのリネージを管理。

--- a/data_flow_dbt/dbt_project.yml
+++ b/data_flow_dbt/dbt_project.yml
@@ -1,34 +1,56 @@
-
-# Name your project! Project names should contain only lowercase characters
-# and underscores. A good package name should reflect your organization's
-# name or the intended use of these models
 name: 'data_flow_dbt'
 version: '1.0.0'
-
-# This setting configures which "profile" dbt uses for this project.
+config-version: 2
 profile: 'data_flow_dbt'
 
-# These configurations specify where dbt should look for different types of files.
-# The `model-paths` config, for example, states that models in this project can be
-# found in the "models/" directory. You probably won't need to change these!
 model-paths: ["models"]
 analysis-paths: ["analyses"]
 test-paths: ["tests"]
 seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
+asset-paths: ["exposures"]
+exposures-paths: ["exposures"]
 
-clean-targets:         # directories to be removed by `dbt clean`
+clean-targets:
   - "target"
   - "dbt_packages"
 
+on-run-start:
+  - "{{ log('Starting dbt run for ' ~ target.name ~ ' environment', info=True) }}"
 
-# Configuring models
-# Full documentation: https://docs.getdbt.com/docs/configuring-models
+on-run-end:
+  - "{{ summarize_run_artifacts(results) }}"
 
-# In this example config, we tell dbt to build all models in the example/
-# directory as views. These settings can be overridden in the individual model
-# files using the `{{ config(...) }}` macro.
+vars:
+  invalid_activity_label: 0
+  source_loaded_at_field: 'ingested_at'
+  incremental_start_time: "date_trunc('day', current_timestamp) - interval '1 day'"
+
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['dbt_utils', 'dbt']
+
 models:
   data_flow_dbt:
-    +materialized: table
+    +persist_docs: {relation: true, columns: true}
+    staging:
+      +materialized: view
+    intermediate:
+      +materialized: ephemeral
+    marts:
+      +materialized: table
+    +tags: ['data-flow']
+
+seeds:
+  data_flow_dbt:
+    +quote_columns: false
+
+snapshots:
+  data_flow_dbt:
+    +target_schema: "{{ target.schema }}"
+    +target_database: "{{ target.database }}"
+
+tests:
+  data_flow_dbt:
+    +store_failures: true

--- a/data_flow_dbt/exposures/exposures.yml
+++ b/data_flow_dbt/exposures/exposures.yml
@@ -1,0 +1,31 @@
+version: 2
+
+exposures:
+  - name: mhealth_feature_dashboard
+    type: dashboard
+    owner:
+      name: Analytics Team
+      email: analytics@example.com
+    maturity: high
+    url: https://bi.example.com/dashboards/mhealth_features
+    description: |
+      Tableau ダッシュボード。`fact_activity_metrics` を参照し、mHealth 活動の傾向を可視化する。
+    depends_on:
+      - ref('fact_activity_metrics')
+    tags: ['bi', 'lineage', 'production']
+    meta:
+      business_impact: medium
+      tier: gold
+
+  - name: ml_training_pipeline
+    type: application
+    owner:
+      name: ML Platform
+      email: ml@example.com
+    description: |
+      SageMaker トレーニングジョブが `featured_activities` を特徴量ストアとして利用する。
+    depends_on:
+      - ref('featured_activities')
+    url: https://ml.example.com/pipelines/mhealth
+    maturity: medium
+    tags: ['ml', 'lineage']

--- a/data_flow_dbt/macros/activity_utils.sql
+++ b/data_flow_dbt/macros/activity_utils.sql
@@ -1,0 +1,11 @@
+{% macro three_axis_average(x, y, z) %}
+    ({{ x }} + {{ y }} + {{ z }}) / 3
+{% endmacro %}
+
+{% macro activity_coalesce_user_id(partition_value, path_partition, path_filename) %}
+    coalesce(
+        {{ partition_value }},
+        regexp_extract({{ path_partition }}, 'subject_id=(\\d+)', 1),
+        regexp_extract({{ path_filename }}, 'mHealth_subject(\\d+)', 1)
+    )
+{% endmacro %}

--- a/data_flow_dbt/macros/run_artifact_summary.sql
+++ b/data_flow_dbt/macros/run_artifact_summary.sql
@@ -1,0 +1,36 @@
+{% macro summarize_run_artifacts(results) %}
+    {% set success = [] %}
+    {% set failures = [] %}
+
+    {% for result in results %}
+        {% if result.status == 'success' %}
+            {% do success.append(result.node.name) %}
+        {% else %}
+            {% do failures.append(result.node.name ~ ' (' ~ result.status ~ ')') %}
+        {% endif %}
+    {% endfor %}
+
+    {% set summary %}{
+        "successful_models": {{ success | tojson }},
+        "failed_models": {{ failures | tojson }},
+        "generated_at": "{{ run_started_at }}"
+    }{% endset %}
+
+    {{ log('dbt artifact summary: ' ~ summary, info=True) }}
+    {% do return(summary) %}
+{% endmacro %}
+
+{% macro artifact_paths() %}
+    {% set target_path = target.path %}
+    {% set manifest_path = target_path ~ '/manifest.json' %}
+    {% set run_results_path = target_path ~ '/run_results.json' %}
+    {% set catalog_path = target_path ~ '/catalog.json' %}
+
+    {% set payload %}{
+        "manifest": "{{ manifest_path }}",
+        "run_results": "{{ run_results_path }}",
+        "catalog": "{{ catalog_path }}"
+    }{% endset %}
+
+    {% do return(payload) %}
+{% endmacro %}

--- a/data_flow_dbt/macros/run_operations.sql
+++ b/data_flow_dbt/macros/run_operations.sql
@@ -1,0 +1,13 @@
+{% macro log_lineage(model_name) %}
+    {% set node = graph.nodes.get('model.data_flow_dbt.' ~ model_name) %}
+    {% if node is none %}
+        {{ exceptions.raise_compiler_error('Model ' ~ model_name ~ ' not found in manifest') }}
+    {% endif %}
+
+    {% set parents = node.depends_on.nodes %}
+    {% set children = graph.child_map.get(node.unique_id, []) %}
+
+    {{ log('Lineage for ' ~ model_name, info=True) }}
+    {{ log('Parents: ' ~ parents | tojson, info=True) }}
+    {{ log('Children: ' ~ children | tojson, info=True) }}
+{% endmacro %}

--- a/data_flow_dbt/macros/tests/non_negative.sql
+++ b/data_flow_dbt/macros/tests/non_negative.sql
@@ -1,0 +1,5 @@
+{% test non_negative(model, column_name) %}
+    select *
+    from {{ model }}
+    where {{ column_name }} < 0
+{% endtest %}

--- a/data_flow_dbt/models/cleaned_activities.sql
+++ b/data_flow_dbt/models/cleaned_activities.sql
@@ -1,31 +1,15 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    tags=['core'],
+    post_hook=[
+        "{{ log('cleaned_activities built at ' ~ run_started_at, info=True) }}"
+    ]
+) }}
 
-WITH source AS (
-
-    SELECT
-        *,
-        -- Extract user_id from partition path or filename as fallback
-        regexp_extract("$path", 'subject_id=(\\d+)', 1) AS user_id_from_partition,
-        regexp_extract("$path", 'mHealth_subject(\\d+)', 1) AS user_id_from_filename
-    FROM
-        {{ source('mhealth_stage', 'raw_activities') }}
-
-),
-
-renamed AS (
-
-    SELECT
-        -- Prefer Glue partition key if present; otherwise fallback to path regexes
-        CAST(subject_id AS varchar) AS user_id,
-        CAST(activity_label AS bigint) AS activity_label,
-        (chest_acc_x + chest_acc_y + chest_acc_z) / 3 AS chest_acc_avg,
-        (left_ankle_acc_x + left_ankle_acc_y + left_ankle_acc_z) / 3 AS left_ankle_acc_avg,
-        (right_lower_arm_acc_x + right_lower_arm_acc_y + right_lower_arm_acc_z) / 3 AS right_lower_arm_acc_avg
-    FROM
-        source
-    WHERE
-        CAST(activity_label AS bigint) != 0
-
-)
-
-SELECT * FROM renamed
+select
+    user_id,
+    activity_label,
+    chest_acc_avg,
+    left_ankle_acc_avg,
+    right_lower_arm_acc_avg
+from {{ ref('int_activity_features') }}

--- a/data_flow_dbt/models/docs.md
+++ b/data_flow_dbt/models/docs.md
@@ -1,0 +1,19 @@
+{% docs stg_mhealth_activities_doc %}
+`stg_mhealth_activities` は Glue カタログの外部テーブルを正規化し、ユーザー ID を `$path` から抽出するビューです。データコントラクトを有効化し、ダウンストリームの中間モデルに対して安定したスキーマを提供します。
+{% enddocs %}
+
+{% docs int_activity_features_doc %}
+`int_activity_features` はエフェメラルモデルとして 3 軸加速度の平均値を計算し、繰り返し利用されるロジックを集約します。
+{% enddocs %}
+
+{% docs cleaned_activities_doc %}
+`cleaned_activities` テーブルは `stg_mhealth_activities` ビューを基に、各センサーの 3 軸加速度の平均値を算出した中間テーブルです。`activity_label` が 0 の無効データを除外し、ユーザー ID を正規化した上で特徴量生成の前処理を担います。
+{% enddocs %}
+
+{% docs featured_activities_doc %}
+`featured_activities` は `cleaned_activities` を `user_id × activity_label` で集約し、平均・標準偏差・最小・最大の代表統計量を算出します。`activity_labels` シードテーブルと結合することでビジネスで利用する説明文を付与します。
+{% enddocs %}
+
+{% docs fact_activity_metrics_doc %}
+`fact_activity_metrics` は `featured_activities` の増分ロード版であり、CI や本番バッチにてマージ戦略で更新されます。`loaded_at` 列により差分抽出を行い、Slim CI などでの効率的な再実行を可能にします。
+{% enddocs %}

--- a/data_flow_dbt/models/featured_activities.sql
+++ b/data_flow_dbt/models/featured_activities.sql
@@ -1,41 +1,43 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    tags=['mart'],
+    pre_hook=[
+        "{{ log('Starting aggregation for featured_activities', info=True) }}"
+    ]
+) }}
 
-WITH cleaned_data AS (
-    SELECT
-        user_id,
-        activity_label,
-        chest_acc_avg,
-        left_ankle_acc_avg,
-        right_lower_arm_acc_avg
-    FROM {{ ref('cleaned_activities') }}
+with cleaned_data as (
+    select *
+    from {{ ref('cleaned_activities') }}
 ),
 
-featured AS (
-    SELECT
-        user_id,
-        activity_label,
-        -- Chest Accelerometer Features
-        avg(chest_acc_avg) AS chest_acc_mean,
-        stddev(chest_acc_avg) AS chest_acc_std,
-        min(chest_acc_avg) AS chest_acc_min,
-        max(chest_acc_avg) AS chest_acc_max,
+activity_dim as (
+    select * from {{ ref('activity_labels') }}
+),
 
-        -- Left Ankle Accelerometer Features
-        avg(left_ankle_acc_avg) AS left_ankle_acc_mean,
-        stddev(left_ankle_acc_avg) AS left_ankle_acc_std,
-        min(left_ankle_acc_avg) AS left_ankle_acc_min,
-        max(left_ankle_acc_avg) AS left_ankle_acc_max,
-
-        -- Right Lower Arm Accelerometer Features
-        avg(right_lower_arm_acc_avg) AS right_lower_arm_acc_mean,
-        stddev(right_lower_arm_acc_avg) AS right_lower_arm_acc_std,
-        min(right_lower_arm_acc_avg) AS right_lower_arm_acc_min,
-        max(right_lower_arm_acc_avg) AS right_lower_arm_acc_max
-    FROM
-        cleaned_data
-    GROUP BY
-        user_id,
-        activity_label
+featured as (
+    select
+        c.user_id,
+        c.activity_label,
+        dim.description as activity_description,
+        avg(c.chest_acc_avg) as chest_acc_mean,
+        stddev(c.chest_acc_avg) as chest_acc_std,
+        min(c.chest_acc_avg) as chest_acc_min,
+        max(c.chest_acc_avg) as chest_acc_max,
+        avg(c.left_ankle_acc_avg) as left_ankle_acc_mean,
+        stddev(c.left_ankle_acc_avg) as left_ankle_acc_std,
+        min(c.left_ankle_acc_avg) as left_ankle_acc_min,
+        max(c.left_ankle_acc_avg) as left_ankle_acc_max,
+        avg(c.right_lower_arm_acc_avg) as right_lower_arm_acc_mean,
+        stddev(c.right_lower_arm_acc_avg) as right_lower_arm_acc_std,
+        min(c.right_lower_arm_acc_avg) as right_lower_arm_acc_min,
+        max(c.right_lower_arm_acc_avg) as right_lower_arm_acc_max
+    from cleaned_data c
+    left join activity_dim dim on c.activity_label = cast(dim.activity_label as bigint)
+    group by
+        c.user_id,
+        c.activity_label,
+        dim.description
 )
 
-SELECT * FROM featured
+select * from featured

--- a/data_flow_dbt/models/intermediate/int_activity_features.sql
+++ b/data_flow_dbt/models/intermediate/int_activity_features.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='ephemeral',
+    tags=['intermediate']
+) }}
+
+select
+    user_id_raw as user_id,
+    activity_label,
+    {{ three_axis_average('chest_acc_x', 'chest_acc_y', 'chest_acc_z') }} as chest_acc_avg,
+    {{ three_axis_average('left_ankle_acc_x', 'left_ankle_acc_y', 'left_ankle_acc_z') }} as left_ankle_acc_avg,
+    {{ three_axis_average('right_lower_arm_acc_x', 'right_lower_arm_acc_y', 'right_lower_arm_acc_z') }} as right_lower_arm_acc_avg
+from {{ ref('stg_mhealth_activities') }}

--- a/data_flow_dbt/models/marts/fact_activity_metrics.sql
+++ b/data_flow_dbt/models/marts/fact_activity_metrics.sql
@@ -1,0 +1,31 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['user_id', 'activity_label'],
+    tags=['mart', 'incremental'],
+    on_schema_change='sync_all_columns',
+    pre_hook=[
+        "{{ log('Running fact_activity_metrics incremental build', info=True) }}"
+    ],
+    post_hook=[
+        "{{ log('Completed fact_activity_metrics incremental build', info=True) }}"
+    ]
+) }}
+
+with source_data as (
+    select
+        fa.user_id,
+        fa.activity_label,
+        fa.activity_description,
+        fa.chest_acc_mean,
+        fa.left_ankle_acc_mean,
+        fa.right_lower_arm_acc_mean,
+        current_timestamp as loaded_at
+    from {{ ref('featured_activities') }} fa
+)
+
+select * from source_data
+
+{% if is_incremental() %}
+where loaded_at >= {{ var('incremental_start_time', "date_trunc('day', current_timestamp) - interval '1 day'") }}
+{% endif %}

--- a/data_flow_dbt/models/metrics.yml
+++ b/data_flow_dbt/models/metrics.yml
@@ -1,0 +1,26 @@
+version: 2
+
+metrics:
+  - name: avg_chest_acceleration
+    label: 平均胸部加速度
+    model: ref('fact_activity_metrics')
+    description: mHealth chest 加速度の平均値をユーザー・活動ラベルで集計するメトリクス。
+    calculation_method: expression
+    expression: avg(chest_acc_mean)
+    timestamp: loaded_at
+    time_grains: [day, week]
+    filters:
+      - field: activity_description
+        operator: is not null
+    dimensions:
+      - user_id
+      - activity_label
+
+  - name: active_user_count
+    label: アクティブユーザー数
+    model: ref('fact_activity_metrics')
+    description: 活動データを保有するユニークユーザー数。
+    calculation_method: count_distinct
+    expression: user_id
+    timestamp: loaded_at
+    time_grains: [day, week]

--- a/data_flow_dbt/models/schema.yml
+++ b/data_flow_dbt/models/schema.yml
@@ -1,86 +1,169 @@
 version: 2
 
 models:
-  - name: cleaned_activities
-    description: |
-      mHealth の stage データをクレンジングした中間テーブル。
-      - Glue の partition（subject_id）または `$path` から user_id を抽出
-      - 3軸加速度の単純平均を算出（chest / left_ankle / right_lower_arm）
-      - activity_label = 0（null クラス）を除外
+  - name: stg_mhealth_activities
+    description: "{{ doc('stg_mhealth_activities_doc') }}"
     columns:
-      - name: user_id
-        description: ユーザー ID（`subject_id` を文字列化）。
+      - name: user_id_raw
+        description: "Glue パーティションまたはファイルパスから抽出したユーザー ID。"
+        data_type: varchar
         tests:
           - not_null
       - name: activity_label
-        description: 活動ラベル（0 は除外対象、1 以降が有効クラス）。
+        description: "活動ラベル（0 は vars.invalid_activity_label で制御）。"
+        data_type: bigint
         tests:
           - not_null
+          - relationships:
+              to: ref('activity_labels')
+              field: activity_label
+      - name: chest_acc_x
+        description: "胸部加速度 X"
+        data_type: double
+      - name: chest_acc_y
+        description: "胸部加速度 Y"
+        data_type: double
+      - name: chest_acc_z
+        description: "胸部加速度 Z"
+        data_type: double
+
+  - name: int_activity_features
+    description: "{{ doc('int_activity_features_doc') }}"
+    columns:
+      - name: user_id
+        data_type: varchar
+        tests:
+          - not_null
+      - name: activity_label
+        data_type: bigint
       - name: chest_acc_avg
-        description: 胸部加速度（X/Y/Z）の単純平均。
+        data_type: double
+        tests:
+          - not_null
+          - non_negative
       - name: left_ankle_acc_avg
-        description: 左足首加速度（X/Y/Z）の単純平均。
+        data_type: double
       - name: right_lower_arm_acc_avg
-        description: 右前腕加速度（X/Y/Z）の単純平均。
+        data_type: double
+
+  - name: cleaned_activities
+    description: "{{ doc('cleaned_activities_doc') }}"
+    columns:
+      - name: user_id
+        description: "ユーザー ID（`subject_id` を文字列化）。"
+        data_type: varchar
+        tests:
+          - not_null
+      - name: activity_label
+        description: "活動ラベル（0 は除外対象、1 以降が有効クラス）。"
+        data_type: bigint
+        tests:
+          - not_null
+          - relationships:
+              to: ref('activity_labels')
+              field: activity_label
+      - name: chest_acc_avg
+        description: "胸部加速度（X/Y/Z）の単純平均。"
+        data_type: double
+        tests:
+          - non_negative
+      - name: left_ankle_acc_avg
+        description: "左足首加速度（X/Y/Z）の単純平均。"
+        data_type: double
+        tests:
+          - non_negative
+      - name: right_lower_arm_acc_avg
+        description: "右前腕加速度（X/Y/Z）の単純平均。"
+        data_type: double
+        tests:
+          - non_negative
 
   - name: featured_activities
-    description: |
-      cleaned_activities を `user_id × activity_label` で集約し、3軸平均の代表統計量を算出した特徴量テーブル。
-      - chest / left_ankle / right_lower_arm それぞれについて mean / std / min / max を計算。
+    description: "{{ doc('featured_activities_doc') }}"
     columns:
       - name: user_id
-        description: ユーザー ID。
+        description: "ユーザー ID。"
+        data_type: varchar
         tests:
           - not_null
       - name: activity_label
-        description: 活動ラベル（1 以降の有効クラス）。
+        description: "活動ラベル（1 以降の有効クラス）。"
+        data_type: bigint
+        tests:
+          - not_null
+          - unique:
+              config:
+                where: "activity_description is not null"
+      - name: activity_description
+        description: "シード由来の活動説明文。"
+        data_type: varchar
         tests:
           - not_null
       - name: chest_acc_mean
-        description: 胸部加速度平均（3軸平均の平均値）。
+        description: "胸部加速度平均（3軸平均の平均値）。"
+        data_type: double
         tests:
           - not_null
       - name: chest_acc_std
-        description: 胸部加速度標準偏差（3軸平均の標準偏差）。
-        tests:
-          - not_null
+        description: "胸部加速度標準偏差（3軸平均の標準偏差）。"
+        data_type: double
       - name: chest_acc_min
-        description: 胸部加速度最小（3軸平均の最小値）。
-        tests:
-          - not_null
+        description: "胸部加速度最小（3軸平均の最小値）。"
+        data_type: double
       - name: chest_acc_max
-        description: 胸部加速度最大（3軸平均の最大値）。
-        tests:
-          - not_null
+        description: "胸部加速度最大（3軸平均の最大値）。"
+        data_type: double
       - name: left_ankle_acc_mean
-        description: 左足首加速度平均（3軸平均の平均値）。
-        tests:
-          - not_null
+        description: "左足首加速度平均（3軸平均の平均値）。"
+        data_type: double
       - name: left_ankle_acc_std
-        description: 左足首加速度標準偏差（3軸平均の標準偏差）。
-        tests:
-          - not_null
+        description: "左足首加速度標準偏差（3軸平均の標準偏差）。"
+        data_type: double
       - name: left_ankle_acc_min
-        description: 左足首加速度最小（3軸平均の最小値）。
-        tests:
-          - not_null
+        description: "左足首加速度最小（3軸平均の最小値）。"
+        data_type: double
       - name: left_ankle_acc_max
-        description: 左足首加速度最大（3軸平均の最大値）。
-        tests:
-          - not_null
+        description: "左足首加速度最大（3軸平均の最大値）。"
+        data_type: double
       - name: right_lower_arm_acc_mean
-        description: 右前腕加速度平均（3軸平均の平均値）。
-        tests:
-          - not_null
+        description: "右前腕加速度平均（3軸平均の平均値）。"
+        data_type: double
       - name: right_lower_arm_acc_std
-        description: 右前腕加速度標準偏差（3軸平均の標準偏差）。
-        tests:
-          - not_null
+        description: "右前腕加速度標準偏差（3軸平均の標準偏差）。"
+        data_type: double
       - name: right_lower_arm_acc_min
-        description: 右前腕加速度最小（3軸平均の最小値）。
-        tests:
-          - not_null
+        description: "右前腕加速度最小（3軸平均の最小値）。"
+        data_type: double
       - name: right_lower_arm_acc_max
-        description: 右前腕加速度最大（3軸平均の最大値）。
+        description: "右前腕加速度最大（3軸平均の最大値）。"
+        data_type: double
+
+  - name: fact_activity_metrics
+    description: "{{ doc('fact_activity_metrics_doc') }}"
+    columns:
+      - name: user_id
+        data_type: varchar
         tests:
           - not_null
+      - name: activity_label
+        data_type: bigint
+        tests:
+          - not_null
+      - name: activity_description
+        data_type: varchar
+      - name: chest_acc_mean
+        data_type: double
+      - name: left_ankle_acc_mean
+        data_type: double
+      - name: right_lower_arm_acc_mean
+        data_type: double
+      - name: loaded_at
+        description: "インクリメンタルロード時の取り込みタイムスタンプ。"
+        data_type: timestamp
+        tests:
+          - not_null
+    meta:
+      owner: analytics
+      product_area: movement
+      service_level: gold
+

--- a/data_flow_dbt/models/src_mhealth.yml
+++ b/data_flow_dbt/models/src_mhealth.yml
@@ -5,9 +5,17 @@ sources:
     description: Kaggle mHealth ログを Parquet 化したステージングデータ（Glue Catalog 経由）。
     database: awsdatacatalog
     schema: "{{ env_var('GLUE_STAGE_DATABASE', 'stage_mhealth') }}"
+    freshness:
+      warn_after: {count: 12, period: hour}
+      error_after: {count: 1, period: day}
+    loaded_at_field: "{{ var('source_loaded_at_field', 'ingested_at') }}"
     tables:
       - name: raw_activities
         description: 24 列の生データ（activity_label を含む）。`subject_id`/`activity_label` でパーティション。
+        external: true
+        meta:
+          owner: data-platform
+          sla: bronze
         columns:
           - name: chest_acc_x
             description: 胸部加速度 X

--- a/data_flow_dbt/models/staging/stg_mhealth_activities.sql
+++ b/data_flow_dbt/models/staging/stg_mhealth_activities.sql
@@ -1,0 +1,28 @@
+{{ config(
+    materialized='view',
+    tags=['staging'],
+    persist_docs={'relation': true, 'columns': true},
+    contract={'enforced': true}
+) }}
+
+with source_data as (
+    select
+        *,
+        {{ activity_coalesce_user_id('cast(subject_id as varchar)', '"$path"', '"$path"') }} as user_id_raw
+    from {{ source('mhealth_stage', 'raw_activities') }}
+)
+
+select
+    user_id_raw,
+    cast(activity_label as bigint) as activity_label,
+    cast(chest_acc_x as double) as chest_acc_x,
+    cast(chest_acc_y as double) as chest_acc_y,
+    cast(chest_acc_z as double) as chest_acc_z,
+    cast(left_ankle_acc_x as double) as left_ankle_acc_x,
+    cast(left_ankle_acc_y as double) as left_ankle_acc_y,
+    cast(left_ankle_acc_z as double) as left_ankle_acc_z,
+    cast(right_lower_arm_acc_x as double) as right_lower_arm_acc_x,
+    cast(right_lower_arm_acc_y as double) as right_lower_arm_acc_y,
+    cast(right_lower_arm_acc_z as double) as right_lower_arm_acc_z
+from source_data
+where cast(activity_label as bigint) != {{ var('invalid_activity_label', 0) }}

--- a/data_flow_dbt/packages.yml
+++ b/data_flow_dbt/packages.yml
@@ -1,0 +1,5 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: ["1.1.0", "<2.0.0"]
+  - package: elementary-data/elementary
+    version: ["0.12.0", "<0.13.0"]

--- a/data_flow_dbt/scripts/ci/dbt_cloud_job_template.yml
+++ b/data_flow_dbt/scripts/ci/dbt_cloud_job_template.yml
@@ -1,0 +1,25 @@
+# dbt Cloud job テンプレート
+name: mhealth nightly build
+environment_id: 12345
+schedule:
+  cron: "0 2 * * *"
+  timezone: Asia/Tokyo
+steps:
+  - name: deps
+    command: dbt deps
+  - name: seed
+    command: dbt seed --select activity_labels
+  - name: build
+    command: dbt build --selector mart_only
+  - name: snapshot
+    command: dbt snapshot
+  - name: docs
+    command: dbt docs generate
+notifications:
+  - channel: slack
+    level: warn
+    destination: https://hooks.slack.com/services/T000/B000/XXXX
+artifacts:
+  upload: true
+  bucket: example-dbt-artifacts
+  prefix: cloud-jobs/nightly

--- a/data_flow_dbt/scripts/ci/dbt_slim_ci.sh
+++ b/data_flow_dbt/scripts/ci/dbt_slim_ci.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_DIR=${1:-"state"}
+TARGET_PATH=${2:-"target"}
+
+if [ -d "$STATE_DIR" ]; then
+  echo "Restoring previous dbt state from $STATE_DIR"
+  mkdir -p "$TARGET_PATH"
+  cp -r "$STATE_DIR"/* "$TARGET_PATH"/ || true
+fi
+
+dbt deps
+
+dbt seed --select activity_labels --full-refresh
+
+dbt build --selector state_modified_plus_seeds --state "$STATE_DIR" --defer --target prod
+
+dbt docs generate
+
+DBT_TARGET_PATH="$TARGET_PATH" python scripts/ci/upload_artifacts.py

--- a/data_flow_dbt/scripts/ci/upload_artifacts.py
+++ b/data_flow_dbt/scripts/ci/upload_artifacts.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Upload dbt artifacts to object storage."""
+
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+import boto3
+
+
+def load_artifact_paths(target_dir: Path) -> Dict[str, str]:
+    manifest = target_dir / "manifest.json"
+    run_results = target_dir / "run_results.json"
+    catalog = target_dir / "catalog.json"
+    return {
+        "manifest": str(manifest),
+        "run_results": str(run_results),
+        "catalog": str(catalog),
+    }
+
+
+def upload_file(client, local_path: Path, bucket: str, prefix: str) -> None:
+    key = f"{prefix}/{local_path.name}"
+    client.upload_file(str(local_path), bucket, key)
+    print(f"Uploaded {local_path} to s3://{bucket}/{key}")
+
+
+def main() -> None:
+    target_dir = Path(os.environ.get("DBT_TARGET_PATH", "target"))
+    if not target_dir.exists():
+        raise SystemExit(f"Target directory {target_dir} does not exist")
+
+    artifact_bucket = os.environ.get("DBT_ARTIFACT_BUCKET", "example-dbt-artifacts")
+    artifact_prefix = os.environ.get("DBT_ARTIFACT_PREFIX", "manifests")
+
+    session = boto3.session.Session()
+    client = session.client("s3")
+
+    artifact_paths = load_artifact_paths(target_dir)
+    for artifact_name, artifact_path in artifact_paths.items():
+        path = Path(artifact_path)
+        if path.exists():
+            upload_file(client, path, artifact_bucket, f"{artifact_prefix}/{artifact_name}")
+        else:
+            print(f"Skipping missing artifact: {path}")
+
+    summary_path = target_dir / "artifact_summary.json"
+    summary = {
+        "bucket": artifact_bucket,
+        "prefix": artifact_prefix,
+        "artifacts": artifact_paths,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False))
+    print(f"Wrote artifact summary to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data_flow_dbt/seeds/activity_labels.csv
+++ b/data_flow_dbt/seeds/activity_labels.csv
@@ -1,0 +1,7 @@
+activity_label,description,is_active
+1,Standing,true
+2,Sitting,true
+3,Lying,true
+4,Walking,true
+5,Running,true
+0,Unknown,false

--- a/data_flow_dbt/seeds/schema.yml
+++ b/data_flow_dbt/seeds/schema.yml
@@ -1,0 +1,20 @@
+version: 2
+
+seeds:
+  - name: activity_labels
+    description: "活動ラベルのメタデータ。dbt seed でロードされ、参照テーブルとして利用。"
+    columns:
+      - name: activity_label
+        description: "活動ラベルの数値識別子"
+        tests:
+          - not_null
+          - unique
+      - name: description
+        description: "活動内容の説明"
+        tests:
+          - not_null
+      - name: is_active
+        description: "有効な活動かどうかのフラグ"
+        tests:
+          - accepted_values:
+              values: ['true', 'false']

--- a/data_flow_dbt/selectors.yml
+++ b/data_flow_dbt/selectors.yml
@@ -1,0 +1,17 @@
+selectors:
+  - name: state_modified_plus_seeds
+    description: Slim CI 用のセレクタ。変更対象と依存モデル＋シードを含める。
+    definition:
+      union:
+        - method: state.modified
+          state: modified
+        - method: state.modified
+          state: modified
+          parents: true
+        - method: fqn
+          value: activity_labels
+
+  - name: mart_only
+    definition:
+      method: tag
+      value: mart

--- a/data_flow_dbt/snapshots/featured_activities_snapshot.sql
+++ b/data_flow_dbt/snapshots/featured_activities_snapshot.sql
@@ -1,0 +1,20 @@
+{% snapshot featured_activities_snapshot %}
+
+{{ config(
+    target_schema=target.schema,
+    target_database=target.database,
+    strategy='check',
+    unique_key=['user_id', 'activity_label'],
+    check_cols=['chest_acc_mean', 'left_ankle_acc_mean', 'right_lower_arm_acc_mean', 'activity_description']
+) }}
+
+select
+    fa.user_id,
+    fa.activity_label,
+    fa.activity_description,
+    fa.chest_acc_mean,
+    fa.left_ankle_acc_mean,
+    fa.right_lower_arm_acc_mean
+from {{ ref('featured_activities') }} fa
+
+{% endsnapshot %}

--- a/data_flow_dbt/tests/fact_activity_metrics_positive.sql
+++ b/data_flow_dbt/tests/fact_activity_metrics_positive.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('fact_activity_metrics') }}
+where chest_acc_mean < 0

--- a/dbt_profiles/profiles.yml
+++ b/dbt_profiles/profiles.yml
@@ -1,0 +1,27 @@
+data_flow_dbt:
+  target: dev
+  outputs:
+    dev:
+      type: athena
+      region_name: "{{ env_var('AWS_REGION', 'us-east-1') }}"
+      s3_staging_dir: "s3://example-dev-dbt-query-results/"
+      work_group: primary
+      database: "{{ env_var('DBT_DEV_DATABASE', 'stage_mhealth') }}"
+      schema: analytics_dev
+      threads: 4
+    stg:
+      type: athena
+      region_name: "{{ env_var('AWS_REGION', 'us-east-1') }}"
+      s3_staging_dir: "s3://example-stg-dbt-query-results/"
+      work_group: analytics
+      database: "{{ env_var('DBT_STG_DATABASE', 'stage_mhealth') }}"
+      schema: analytics_stg
+      threads: 6
+    prod:
+      type: athena
+      region_name: "{{ env_var('AWS_REGION', 'us-east-1') }}"
+      s3_staging_dir: "s3://example-prod-dbt-query-results/"
+      work_group: prod
+      database: "{{ env_var('DBT_PROD_DATABASE', 'stage_mhealth') }}"
+      schema: analytics_prod
+      threads: 8


### PR DESCRIPTION
## Summary
- add staging, intermediate, mart, and snapshot layers with contracts, incremental logic, and seeds to cover dbt materializations
- introduce macros, custom tests, metrics, exposures, and docs to support data contracts, lineage, and semantic layer
- provide CI tooling, selectors, profiles, and artifact upload scripts to enable Slim CI and artifact management

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105526fc188329b967c86bd11e2674)